### PR TITLE
fix(healthCheck): fixed dynamic property error for PHP 8

### DIFF
--- a/Decidir/lib/HealthCheck.php
+++ b/Decidir/lib/HealthCheck.php
@@ -3,7 +3,7 @@ namespace Decidir;
 
 class HealthCheck{
 	public $data = array();
-	public $header_data = NULL;
+	public $header_http = NULL;
 	public $mode = NULL;
 	public $instanceHk = NULL;
 


### PR DESCRIPTION
This PR fixes error for PHP 8 implementations about dynamic property creation:

```
Error message: error-exception
Exception: Creation of dynamic property Decidir\HealthCheck::$header_http is deprecated
File: /home/customer/www/shiftdigital.com.ar/public_html/vendor/decidir2/php-sdk/Decidir/lib/HealthCheck.php
Line: 11
```